### PR TITLE
#74 タスクを完了・削除した際にタスク詳細を閉じるように変更

### DIFF
--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -248,6 +248,8 @@ const Todo: FC = () => {
     const oldTasks = [...tasks];
     const newTasks = oldTasks.filter((t) => t.id !== task.id);
 
+    setTaskDetailOpen(false);
+
     if (task.hasRepeat) {
       finishRepeatTask(task)
         .then((t) => {
@@ -269,6 +271,8 @@ const Todo: FC = () => {
     const oldTasks = [...tasks];
     const newTasks = oldTasks.filter((t) => t.id !== task.id);
     setTasks(newTasks);
+
+    setTaskDetailOpen(false);
 
     deleteTask(task).catch(() => {
       setErrorMessage(


### PR DESCRIPTION
# 目的
タスク完了・削除後にタスク詳細が開かれていると存在しないタスクの詳細情報をいじることになる
これはバグを起こす原因となるため、タスク詳細のドロワーを閉じることで対応する