### PR TITLE
#100 componentのレンダー回数を減らすためにtaskDetailをTaskDetailコンポーネントで持つようにした

### DIFF
--- a/src/components/TaskDetail.tsx
+++ b/src/components/TaskDetail.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState, useEffect } from 'react';
 import {
   Drawer,
   IconButton,
@@ -41,12 +41,8 @@ const useStyles = makeStyles(() =>
 type Props = {
   oepn: boolean;
   drawerClose: () => void;
-  taskDetail: Task;
-  titleChange: (title: string) => void;
-  expirationDateChange: (expirationDate: dayjs.Dayjs) => void;
-  dueDateChange: (dueDate: dayjs.Dayjs) => void;
-  memoChange: (memo: string) => void;
-  repeatChange: (repeat: RepeatType) => void;
+  task: Task;
+  changeTasks: (task: Task) => void;
   updateFirestoreTaskTitle: (taskid: string) => void;
   updateFirestoreTaskExpirationDate: (taskid: string) => void;
   updateFirestoreTaskDueDate: (taskid: string) => void;
@@ -54,15 +50,26 @@ type Props = {
   updateFirestoreTaskRepeat: (taskid: string) => void;
 };
 
+const repeatValues = [
+  {
+    value: 'none',
+    label: '未設定',
+  },
+  {
+    value: 'daily',
+    label: '毎日',
+  },
+  {
+    value: 'monthly',
+    label: '毎月',
+  },
+];
+
 const TodoDetail: FC<Props> = ({
   oepn,
   drawerClose,
-  taskDetail,
-  titleChange,
-  expirationDateChange,
-  dueDateChange,
-  memoChange,
-  repeatChange,
+  task,
+  changeTasks,
   updateFirestoreTaskTitle,
   updateFirestoreTaskExpirationDate,
   updateFirestoreTaskDueDate,
@@ -70,20 +77,9 @@ const TodoDetail: FC<Props> = ({
   updateFirestoreTaskRepeat,
 }) => {
   const classes = useStyles();
-  const repeatValues = [
-    {
-      value: 'none',
-      label: '未設定',
-    },
-    {
-      value: 'daily',
-      label: '毎日',
-    },
-    {
-      value: 'monthly',
-      label: '毎月',
-    },
-  ];
+  const [taskDetail, setTaskDetail] = useState(task);
+
+  useEffect(() => setTaskDetail(task), [task]);
 
   return (
     <MuiPickersUtilsProvider locale={ja} utils={DayJsUtils}>
@@ -104,8 +100,13 @@ const TodoDetail: FC<Props> = ({
               value={taskDetail.title}
               label="タスク"
               fullWidth
-              onChange={(e) => titleChange(e.target.value)}
-              onBlur={() => updateFirestoreTaskTitle(taskDetail.id)}
+              onChange={(e) =>
+                setTaskDetail({ ...taskDetail, title: e.target.value })
+              }
+              onBlur={() => {
+                updateFirestoreTaskTitle(taskDetail.id);
+                changeTasks(taskDetail);
+              }}
             />
           </ListItem>
         </List>
@@ -120,7 +121,10 @@ const TodoDetail: FC<Props> = ({
               onChange={(date) => {
                 if (date) {
                   const strDate = date.toString();
-                  expirationDateChange(dayjs(strDate));
+                  setTaskDetail({
+                    ...taskDetail,
+                    expirationDate: dayjs(strDate),
+                  });
                 }
               }}
               format="YYYY/MM/DD"
@@ -136,7 +140,7 @@ const TodoDetail: FC<Props> = ({
               onChange={(date) => {
                 if (date) {
                   const strDate = date.toString();
-                  dueDateChange(dayjs(strDate));
+                  setTaskDetail({ ...taskDetail, dueDate: dayjs(strDate) });
                 }
               }}
               format="YYYY/MM/DD"
@@ -149,7 +153,12 @@ const TodoDetail: FC<Props> = ({
               fullWidth
               label="繰り返し設定"
               value={taskDetail.repeat}
-              onChange={(e) => repeatChange(e.target.value as RepeatType)}
+              onChange={(e) =>
+                setTaskDetail({
+                  ...taskDetail,
+                  repeat: e.target.value as RepeatType,
+                })
+              }
               onBlur={() => updateFirestoreTaskRepeat(taskDetail.id)}
             >
               {repeatValues.map((repeatValue) => (
@@ -167,7 +176,9 @@ const TodoDetail: FC<Props> = ({
               value={taskDetail.memo ?? ``}
               fullWidth
               multiline
-              onChange={(t) => memoChange(t.target.value)}
+              onChange={(e) =>
+                setTaskDetail({ ...taskDetail, memo: e.target.value })
+              }
               label="メモ"
               onBlur={() => updateFirestoreTaskMemo(taskDetail.id)}
             />

--- a/src/components/Tasks.tsx
+++ b/src/components/Tasks.tsx
@@ -18,7 +18,7 @@ import { AuthContext } from '../contexts/Auth';
 import AddTask from './AddTask';
 import firebase, { db } from '../config/Firebase';
 import Task, { RepeatType } from '../types/task';
-import ToDoDetail from './TaskDetail';
+import TaskDetail from './TaskDetail';
 import Menu from './Menu';
 import AllTasks from './AllTasks';
 import TodayTasks from './TodayTasks';
@@ -69,19 +69,9 @@ const Tasks: FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const { updateTasks } = useFirestoreUpdateTasks(tasks);
   const [currentUrl, setCurrentUrl] = useState('/tasks/all');
-
-  const defaultTaskDetail: Task = {
-    id: '',
-    title: '',
-    expirationDate: dayjs(),
-    dueDate: dayjs(),
-    memo: '',
-    repeat: 'none',
-  };
-
-  const [taskDetail, setTaskDetail] = useState(defaultTaskDetail);
   const { user, setUser } = useContext(AuthContext);
   const { uid } = user;
+  const [taskDetailId, setTaskDetailId] = useState('');
 
   const {
     firestoreUpdateTitle,
@@ -134,13 +124,13 @@ const Tasks: FC = () => {
     ['/tasks/today', '今日のタスク'],
   ]);
 
-  const handleDrawerOpen = (task: Task) => {
-    setTaskDetail(task);
+  const drawerOpen = (task: Task) => {
+    setTaskDetailId(task.id);
     setTaskDetailOpen(true);
   };
 
-  const handleDrawerClose = () => {
-    setTaskDetail(defaultTaskDetail);
+  const drawerClose = () => {
+    setTaskDetailId('');
     setTaskDetailOpen(false);
   };
 
@@ -152,44 +142,7 @@ const Tasks: FC = () => {
     setMenuOpen(false);
   };
 
-  const handleTaskTitleChange = (title: string) => {
-    const task = { ...taskDetail, title };
-    setTaskDetail(task);
-
-    const newTasks = updateTasks(task);
-    setTasks(newTasks);
-  };
-
-  const handleTaskDetailExpirationDateChange = (
-    expirationDate: dayjs.Dayjs,
-  ) => {
-    const task = { ...taskDetail, expirationDate };
-    setTaskDetail(task);
-
-    const newTasks = updateTasks(task);
-    setTasks(newTasks);
-  };
-
-  const handleTaskDetailDueDateChange = (dueDate: dayjs.Dayjs) => {
-    const task = { ...taskDetail, dueDate };
-    setTaskDetail(task);
-
-    const newTasks = updateTasks(task);
-    setTasks(newTasks);
-  };
-
-  const handleTaskDetailMemoChange = (memo: string) => {
-    const task = { ...taskDetail, memo };
-    setTaskDetail(task);
-
-    const newTasks = updateTasks(task);
-    setTasks(newTasks);
-  };
-
-  const handleRepeactChange = (repeat: RepeatType) => {
-    const task = { ...taskDetail, repeat };
-    setTaskDetail(task);
-
+  const changeTasks = (task: Task) => {
     const newTasks = updateTasks(task);
     setTasks(newTasks);
   };
@@ -309,6 +262,23 @@ const Tasks: FC = () => {
     });
   };
 
+  const defaultTask: Task = {
+    id: '',
+    title: '',
+    expirationDate: dayjs(),
+    dueDate: dayjs(),
+    memo: '',
+    repeat: 'none',
+  };
+
+  const taskDetail = () => {
+    const tk = tasks.find((t) => t.id === taskDetailId) ?? defaultTask;
+    // eslint-disable-next-line
+    console.log(tk);
+
+    return tk;
+  };
+
   return (
     <>
       <AppBar
@@ -354,7 +324,7 @@ const Tasks: FC = () => {
               tasks={tasks}
               taskFinish={taskFinish}
               taskDelete={taskDelete}
-              openDrawer={handleDrawerOpen}
+              openDrawer={drawerOpen}
             />
           </PrivateRoute>
           <PrivateRoute path="/tasks/today">
@@ -362,7 +332,7 @@ const Tasks: FC = () => {
               tasks={tasks}
               taskFinish={taskFinish}
               taskDelete={taskDelete}
-              openDrawer={handleDrawerOpen}
+              openDrawer={drawerOpen}
             />
           </PrivateRoute>
           <PrivateRoute path="/tasks">
@@ -370,15 +340,11 @@ const Tasks: FC = () => {
           </PrivateRoute>
         </Switch>
       </main>
-      <ToDoDetail
+      <TaskDetail
         oepn={taskDetailOpen}
-        taskDetail={taskDetail}
-        drawerClose={handleDrawerClose}
-        titleChange={handleTaskTitleChange}
-        expirationDateChange={handleTaskDetailExpirationDateChange}
-        dueDateChange={handleTaskDetailDueDateChange}
-        memoChange={handleTaskDetailMemoChange}
-        repeatChange={handleRepeactChange}
+        task={taskDetail()}
+        changeTasks={changeTasks}
+        drawerClose={drawerClose}
         updateFirestoreTaskTitle={updateFirestoreTaskTitle}
         updateFirestoreTaskExpirationDate={updateFirestoreTaskExpirationDate}
         updateFirestoreTaskDueDate={updateFirestoreTaskDueDate}


### PR DESCRIPTION
# 目的
componentのレンダー回数が多いことによる動作のもたつきを減らす

# 達成条件
タスク詳細の情報を修正している際に、タスクリストが再描画されていないことを確認する